### PR TITLE
Bump urllib3 from 1.24.1 to 1.24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ chardet==3.0.4
 idna==2.8
 requests==2.21.0
 sseclient-py==1.7
-urllib3==1.24.1
+urllib3==1.24.2


### PR DESCRIPTION
**Changelog**
Sourced from urllib3's changelog.

1.24.2 (2019-04-17)

> Don't load system certificates by default when any other ca_certs, ca_certs_dir or
> ssl_context parameters are specified.

> Remove Authorization header regardless of case when redirecting to cross-site. (Issue #1510)
> 
> Add support for IPv6 addresses in subjectAltName section of certificates. (Issue #1269)